### PR TITLE
Process diffuse using GLSL compute shader

### DIFF
--- a/assets/shaders/compute/diffusion.cs.glsl
+++ b/assets/shaders/compute/diffusion.cs.glsl
@@ -1,0 +1,96 @@
+#version 430
+
+// These need to match the workgroup size on Java side
+layout(local_size_x = 8, local_size_y = 8) in;
+
+const int FILTER_SIZE = 3;
+
+layout(binding = 0, rgba8ui) uniform uimage2D outPixels;
+layout(binding = 1, rgba8ui) uniform uimage2D pixels;
+
+uniform int width;
+uniform int height;
+uniform int channels;
+
+void main() {
+    int x = int(gl_GlobalInvocationID.x);
+    int y = int(gl_GlobalInvocationID.y);
+
+    if (x > width || y > height) return;
+    
+    // See voidStartDistance in SimulationSettings
+    float world_radius = 30.0;
+
+    float cellSizeX = 2 * world_radius / float(width);
+    float cellSizeY = 2 * world_radius / float(height);
+    float world_x = -world_radius + cellSizeX * x;
+    float world_y = -world_radius + cellSizeY * y;
+    float dist2_to_world_centre = world_x*world_x + world_y*world_y;
+
+    // set alpha decay to zero as we approach the void
+    float decay = 0.0;
+
+    float void_p = 0.9;
+    if (dist2_to_world_centre > void_p * void_p * world_radius * world_radius) {
+        float dist_to_world_centre = sqrt(dist2_to_world_centre);
+        // lerp from 1.0 to 0.0 for distance between void_p*world_radius and world_radius
+        decay = 0.9995 * (1.0 - (dist_to_world_centre - void_p * world_radius) / ((1.0 - void_p) * world_radius));
+        if (decay < 0.0) {
+            decay = 0.0;
+        }
+    } else {
+        decay = 0.995;
+    }
+
+    int alpha_channel = channels - 1;
+    uvec4 outp;
+
+    float final_alpha = 0.0;
+    int radius = (FILTER_SIZE - 1) / 2;
+    for (int i = -radius; i <= radius; i++) {
+        for (int j = -radius; j <= radius; j++) {
+            int x_ = x + i;
+            int y_ = y + j;
+            if (x_ < 0 || x_ >= width || y_ < 0 || y_ >= height) {
+                continue;
+            }
+            uvec4 pixel = imageLoad(pixels, ivec2(x_, y_));
+            float val = float(pixel[alpha_channel]) / 255.0;
+            final_alpha += val;
+        }
+    }
+    final_alpha = decay * final_alpha / float(FILTER_SIZE*FILTER_SIZE);
+    outp[alpha_channel] = int(255 * final_alpha);
+
+    if (final_alpha < 5.0 / 255.0) {
+        for (int i = 0; i < channels - 1; i++) {
+            outp[i] = 0;
+        }
+    }
+
+    float final_value = 0.0;
+    // assume that the last channel is alpha
+    for (int c = 0; c < channels - 1; c++) {
+        final_value = 0.0;
+        for (int i = -radius; i <= radius; i++) {
+            for (int j = -radius; j <= radius; j++) {
+                int x_ = x + i;
+                int y_ = y + j;
+                if (x_ < 0 || x_ >= width || y_ < 0 || y_ >= height) {
+                    continue;
+                }
+                uvec4 pixel = imageLoad(pixels, ivec2(x_, y_));
+                float alpha = decay * float(pixel[alpha_channel]) / 255.0;
+                float val = float(pixel[c]) / 255.0;
+                final_value += val * alpha;
+            }
+        }
+        final_value = final_value / float(FILTER_SIZE*FILTER_SIZE);
+        final_value = decay * 255 * final_value / final_alpha;
+
+        outp[c] = uint(int(final_value));
+    }
+    outp[3] = 255;
+    
+    imageStore(outPixels, ivec2(x, y), outp);
+}

--- a/assets/shaders/compute/diffusion.cs.glsl
+++ b/assets/shaders/compute/diffusion.cs.glsl
@@ -90,7 +90,6 @@ void main() {
 
         outp[c] = uint(int(final_value));
     }
-    outp[3] = 255;
     
     imageStore(outPixels, ivec2(x, y), outp);
 }

--- a/core/src/com/protoevo/core/ApplicationManager.java
+++ b/core/src/com/protoevo/core/ApplicationManager.java
@@ -249,7 +249,6 @@ public class ApplicationManager {
         graphics = new GraphicsAdapter(this);
         // Creates graphics and runs updates from rendering loop
         new Lwjgl3Application(graphics, config);
-
     }
 
     public void disposeSimulationIfPresent() {

--- a/core/src/com/protoevo/core/ApplicationManager.java
+++ b/core/src/com/protoevo/core/ApplicationManager.java
@@ -10,10 +10,12 @@ import com.protoevo.utils.DebugMode;
 import java.util.Map;
 
 import static com.protoevo.utils.Utils.parseArgs;
+import static org.lwjgl.glfw.GLFW.glfwGetCurrentContext;
 
 public class ApplicationManager {
 
     public final static boolean windowed = false, borderlessWindowed = true;
+    public static long window = 0;
     private volatile boolean headless = false, applicationRunning = true, saveOnExit = true;
     private boolean onlyHeadless = false;
     private Simulation simulation;
@@ -156,6 +158,9 @@ public class ApplicationManager {
     }
 
     public void update() {
+        if(ApplicationManager.window == 0)
+            ApplicationManager.window = glfwGetCurrentContext();
+
         if (hasSimulation() && simulation.isReady()) {
 
             if (hasRemoteGraphics() && sendRemoteGraphicsRequested) {
@@ -244,6 +249,7 @@ public class ApplicationManager {
         graphics = new GraphicsAdapter(this);
         // Creates graphics and runs updates from rendering loop
         new Lwjgl3Application(graphics, config);
+
     }
 
     public void disposeSimulationIfPresent() {

--- a/core/src/com/protoevo/env/ChemicalSolution.java
+++ b/core/src/com/protoevo/env/ChemicalSolution.java
@@ -24,6 +24,7 @@ public class ChemicalSolution implements Serializable {
     private Colour[][] colours;
     private float timeSinceUpdate = 0;
     private transient JCudaKernelRunner diffusionKernel;
+    private transient GLComputeShaderRunner diffusionShader;
 
     public interface ChemicalUpdatedCallback {
         void onChemicalUpdated(int i, int j, Colour colour);
@@ -69,10 +70,12 @@ public class ChemicalSolution implements Serializable {
                     colours[i][j] = new Colour();
                 }
             }
+            diffusionShader = new GLComputeShaderRunner("diffusion");
 
             initialised = true;
         }
 
+        /*
         if (!JCudaKernelRunner.cudaAvailable())
             Environment.settings.misc.useCUDA.set(false);
 
@@ -80,8 +83,9 @@ public class ChemicalSolution implements Serializable {
             // has to be called on the same thread running the simulation
             if (DebugMode.isDebugMode())
                 System.out.println("Initialising chemical diffusion CUDA kernel...");
-            diffusionKernel = new JCudaKernelRunner("diffusion");
+            //diffusionKernel = new JCudaKernelRunner("diffusion");
         }
+        */
     }
 
     public float getFieldWidth() {
@@ -255,10 +259,10 @@ public class ChemicalSolution implements Serializable {
         loadIntoByteBuffer();
 
         try {
-            if (diffusionKernel == null)
+            if (diffusionShader == null)
                 initialise();
 
-            diffusionKernel.processImage(
+            diffusionShader.processImage(
                     byteBuffer, chemicalTextureWidth, chemicalTextureHeight);
         }
         catch (Exception e) {

--- a/core/src/com/protoevo/settings/MiscSettings.java
+++ b/core/src/com/protoevo/settings/MiscSettings.java
@@ -63,6 +63,10 @@ public class MiscSettings extends Settings {
             "Use CUDA",
             "Whether or not to use the CUDA for accelerating calculations on the GPU.",
             true);
+    public final Settings.Parameter<Boolean> useOpenGL = new Settings.Parameter<>(
+            "Use OpenGL",
+            "Whether or not to use OpenGL compute shaders for accelerating calculations on the GPU.",
+            true);
     public final Settings.Parameter<Integer> chemicalCPUIterations = new Settings.Parameter<>(
             "CPU Chemical Diffusion Iterations",
             "Number of chemical diffusion iterations to perform when running on the CPU.",

--- a/core/src/com/protoevo/utils/GLComputeShaderRunner.java
+++ b/core/src/com/protoevo/utils/GLComputeShaderRunner.java
@@ -19,13 +19,13 @@ public class GLComputeShaderRunner {
 
     private final int blockSizeX, blockSizeY;
     private final String kernelName;
-    private int program, computeShader;
     private long window;
     private boolean initialized = false;
     private ByteBuffer inputBuffer = BufferUtils.createByteBuffer(1024*1024*4);
     private ByteBuffer outputBuffer = BufferUtils.createByteBuffer(1024*1024*4);
 
     /* OpenGL resources */
+    private int program, computeShader;
     private int[] textures = new int[2];
 
     public GLComputeShaderRunner(String kernelName) {

--- a/core/src/com/protoevo/utils/GLComputeShaderRunner.java
+++ b/core/src/com/protoevo/utils/GLComputeShaderRunner.java
@@ -1,0 +1,179 @@
+package com.protoevo.utils;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.lwjgl.glfw.GLFW.*;
+import static org.lwjgl.system.MemoryUtil.*;
+import static org.lwjgl.opengl.GL43C.*;
+
+import org.lwjgl.BufferUtils;
+
+import com.protoevo.core.ApplicationManager;
+
+
+public class GLComputeShaderRunner {
+    static final int FILTER_SIZE = 3;
+
+    private final int blockSizeX, blockSizeY;
+    private final String kernelName;
+    private int program, computeShader;
+    private long window;
+    private boolean initialized = false;
+    private ByteBuffer inputBuffer = BufferUtils.createByteBuffer(1024*1024*4);
+    private ByteBuffer outputBuffer = BufferUtils.createByteBuffer(1024*1024*4);
+
+    /* OpenGL resources */
+    private int[] textures = new int[2];
+
+    public GLComputeShaderRunner(String kernelName) {
+        this(kernelName, "kernel", 8, 8);
+    }
+
+    public GLComputeShaderRunner(String kernelName, String functionName, int blockSizeX, int blockSizeY) {
+        System.out.println("Creating GLComputeShaderRunner");
+        this.blockSizeX = blockSizeX;
+        this.blockSizeY = blockSizeY;
+        this.kernelName = kernelName;
+    }
+
+    private void initialise() {
+        if (initialized)
+            return;
+
+        int error = 0;
+        // Create the compute shader
+        if (!glfwInit())
+            throw new AssertionError("Failed to initialize GLFW");
+
+        window = ApplicationManager.window;
+        if (window == NULL)
+            throw new AssertionError("Failed to create GLFW window");
+        glfwMakeContextCurrent(window);
+
+        computeShader = glCreateShader(GL_COMPUTE_SHADER);
+
+        // Load the shader source code
+        String shaderSource = null;
+        try {
+            shaderSource = new String(Files.readAllBytes(Paths.get("shaders/compute/" + kernelName + ".cs.glsl")), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new RuntimeException("Was unable to load " + kernelName + ":\n" + e);
+        }
+
+        // Compile the compute shader
+        glShaderSource(computeShader, shaderSource);
+        glCompileShader(computeShader);
+        if (glGetShaderi(computeShader, GL_COMPILE_STATUS) != GL_TRUE) {
+            throw new RuntimeException("Failed to compile compute shader:\n" + glGetShaderInfoLog(computeShader));
+        }
+
+        // Create the program and attach the compute shader
+        program = glCreateProgram();
+        error = glGetError();
+        if (error != GL_NO_ERROR) {
+            System.out.println("Error creating GL program: " + error);
+        }
+
+        glAttachShader(program, computeShader);
+
+        // Link the program
+        glLinkProgram(program);
+        if (glGetProgrami(program, GL_LINK_STATUS) != GL_TRUE) {
+            throw new RuntimeException("Failed to link program:\n" + glGetProgramInfoLog(program));
+        }
+
+        glUseProgram(program);
+
+        // Delete the compute shader
+        glDeleteShader(computeShader);
+
+        // Create output texture
+        textures[0] = glGenTextures();
+        glBindTexture(GL_TEXTURE_2D, textures[0]);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        final int texSize = 1024; // Was 2048
+        glTexStorage2D(GL_TEXTURE_2D, 1, GL_RGBA8UI, texSize, texSize);
+
+        // Create input texture
+        textures[1] = glGenTextures();
+        glBindTexture(GL_TEXTURE_2D, textures[1]);
+        glBindImageTexture(1, textures[1], 0, false, 0, GL_READ_WRITE, GL_RGBA8UI);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        ByteBuffer inputBuffer = BufferUtils.createByteBuffer(texSize*texSize*4);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8I, texSize, texSize, 0, GL_RGBA_INTEGER, GL_BYTE, inputBuffer);
+
+        error = glGetError();
+        if (error != GL_NO_ERROR) {
+            System.out.println("GL Compute Shader Runner Init Error: " + error);
+        }
+
+        initialized = true;
+    }
+
+    public byte[] processImage(byte[] pixels, int w, int h) {
+        return processImage(pixels, pixels, w, h, 4);
+    }
+
+    public byte[] processImage(byte[] pixels, byte[] result, int w, int h) {
+        return processImage(pixels, result, w, h, 4);
+    }
+
+    public byte[] processImage(byte[] pixels, byte[] result, int w, int h, int c) {
+        if (!initialized) {
+            if (ApplicationManager.window == NULL) {
+                System.out.println("Window is null");
+                return result;
+            } else {
+                initialise();
+            }
+        }
+        glBindImageTexture(0, textures[0], 0, false, 0, GL_READ_WRITE, GL_RGBA8UI);
+        glBindImageTexture(1, textures[1], 0, false, 0, GL_READ_WRITE, GL_RGBA8UI);
+
+        // Bind the program and set the input and output buffer bindings
+        glUseProgram(program);
+
+        // Set the kernel parameters
+        glUniform1i(glGetUniformLocation(program, "width"), w);
+        glUniform1i(glGetUniformLocation(program, "height"), h);
+        glUniform1i(glGetUniformLocation(program, "channels"), c);
+
+        // Copy the input to the input buffer and then to shader
+        inputBuffer.position(0);
+        inputBuffer.put(pixels);
+        inputBuffer.position(0);
+
+        glBindTexture(GL_TEXTURE_2D, textures[1]);
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w, h, GL_RGBA_INTEGER, GL_BYTE, inputBuffer);
+        glBindTexture(GL_TEXTURE_2D, 0);
+
+        // Dispatch the compute shader
+        int gridSizeX = (int) Math.ceil((double) w / blockSizeX);
+        int gridSizeY = (int) Math.ceil((double) h / blockSizeY);
+
+        // Compute runs in ~0ms
+        glDispatchCompute(gridSizeX, gridSizeY, 1);
+
+        // Wait for the compute shader to finish
+        glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
+
+        // Get the output from shader to outputBuffer and then to result array
+        glBindTexture(GL_TEXTURE_2D, textures[0]);
+        glBindImageTexture(0, textures[0], 0, false, 0, GL_READ_ONLY, GL_RGBA8UI);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        outputBuffer.position(0);
+        glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA_INTEGER, GL_UNSIGNED_BYTE, outputBuffer);
+        glBindTexture(GL_TEXTURE_2D, 0);
+        outputBuffer.get(result);
+
+        return result;
+    }
+}


### PR DESCRIPTION
OpenGL compute, GLSL, shader for calculating diffuse without requiring CUDA. Works on other GPUs in addition to Nvidia.

Changes:
- [x] Use cuda if the setting is enabled, otherwise opengl
- [x] Option for opengl

Performance:
Currently takes 8-9ms to copy data to CPU to GPU, run the compute shader, copy data back from GPU to CPU. Double the time of the CUDA approach. However, there are much better opportunities for optimization in the unloadFromByteBuffer and loadIntoByteBuffer methods:
![image](https://github.com/DylanCope/ProtoEvo/assets/5957589/69a712e7-43ca-4835-a61b-5d3649cd3bdb)
