### PR TITLE
Return original timestamp string if not right format

### DIFF
--- a/core/src/com/protoevo/ui/LoadSaveScreen.java
+++ b/core/src/com/protoevo/ui/LoadSaveScreen.java
@@ -75,6 +75,12 @@ public class LoadSaveScreen extends ScreenAdapter {
         // want to reformat to day/month/year hour:minute:second
 
         String[] splitTimeStamp = timeStamp.split("-");
+
+        if(splitTimeStamp.length != 6){
+            // if the time stamp is not of the correct format, return the original string
+            return timeStamp;
+        }
+
         int year = Integer.parseInt(splitTimeStamp[0]);
         int month = Integer.parseInt(splitTimeStamp[1]);
         int day = Integer.parseInt(splitTimeStamp[2]);


### PR DESCRIPTION
Listing saves fails if there's an "autosave" which is not a valid timestamp of form year-month-day-hour-minute-second:
```
Caused by: java.lang.NumberFormatException: For input string: "autosave"

	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.base/java.lang.Integer.parseInt(Integer.java:652)
	at java.base/java.lang.Integer.parseInt(Integer.java:770)
	at com.protoevo.ui.LoadSaveScreen.reformatTimeStampString(LoadSaveScreen.java:78)
	at com.protoevo.ui.LoadSaveScreen.getStatsMap(LoadSaveScreen.java:101)
	at com.protoevo.ui.LoadSaveScreen.addLoadScrollItem(LoadSaveScreen.java:125)
	at com.protoevo.ui.LoadSaveScreen.lambda$new$0(LoadSaveScreen.java:54)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
```

Change: If timestamp is not valid, returning the original string timestamp that was passed to the function instead, that is in this case "autosave".