### PR TITLE
GLThread with a separate hidden window

### DIFF
--- a/core/src/com/protoevo/core/ApplicationManager.java
+++ b/core/src/com/protoevo/core/ApplicationManager.java
@@ -158,14 +158,7 @@ public class ApplicationManager {
         }
     }
 
-    public static void ensureWindowUpToDate() {
-        if (ApplicationManager.window == 0)
-            ApplicationManager.window = glfwGetCurrentContext();
-    }
-
     public void update() {
-        ensureWindowUpToDate();
-
         if (hasSimulation() && simulation.isReady()) {
 
             if (hasRemoteGraphics() && sendRemoteGraphicsRequested) {


### PR DESCRIPTION
Run GLComputeShaderRunner tasks in a separate thread that has a different opengl context. A new hidden window is used as the context. Removes the need to rely on ApplicationManager window and since the hidden window is not destroyed when switching to terminal only mode, the GLSL shader runs fine even if libgdx app has been exited.